### PR TITLE
fix outputting float and dword to file

### DIFF
--- a/lib/modbus-cli/read_command.rb
+++ b/lib/modbus-cli/read_command.rb
@@ -168,7 +168,7 @@ module Modbus
           case addr_type
           when :bit
             (addr + 1).to_s
-          when :word, :int
+          when :word, :int, :dword, :float
             case addr_area
             when :input_registers
               (addr + 300001).to_s


### PR DESCRIPTION
issue is offset is empty when using --output using float or dword
so using dump *.yml doesnt work correctly

plz check as fix not tested as ive never done any ruby
how to test
modbus read --output test.yml -p 502 192.168.0.2 %MF100 50

test.yml will not have any offset